### PR TITLE
Fixed a byte order bug in BrowseService.cs.

### DIFF
--- a/src/Mono.Zeroconf.Providers.Bonjour/Mono.Zeroconf.Providers.Bonjour/BrowseService.cs
+++ b/src/Mono.Zeroconf.Providers.Bonjour/Mono.Zeroconf.Providers.Bonjour/BrowseService.cs
@@ -113,7 +113,7 @@ namespace Mono.Zeroconf.Providers.Bonjour
             
             InterfaceIndex = interfaceIndex;
             FullName = fullname;
-            this.port = port;
+            this.port = (ushort)IPAddress.NetworkToHostOrder((short)port);
             TxtRecord = new TxtRecord(txtLen, txtRecord);
 
             sdRef.Deallocate();


### PR DESCRIPTION
Changed BrowseService.cs due to recent changes in byte order handling.
Port numbers returned by resolved services should now be correct.